### PR TITLE
Fix blank strings occasionally being returned

### DIFF
--- a/src/getRandomQuotes.ts
+++ b/src/getRandomQuotes.ts
@@ -5,7 +5,7 @@ import quotes from "./quotes";
 const range = (count: number) => Array<number>(count).fill(1);
 
 const appendRandomQuote = (currentQuotes: string[]): string[] => {
-    const quote = quotes[Math.floor(Math.random() * quotes.length)] || '';
+    const quote = quotes[Math.floor(Math.random() * quotes.length)];
 
     return currentQuotes.includes(quote)
         ? appendRandomQuote(currentQuotes)

--- a/src/quotes.ts
+++ b/src/quotes.ts
@@ -102,7 +102,7 @@ export default [
     "First rule. No conversation lasts longer than 100 total words.",
     "I will leave my children $50 a piece. Enough for the cab ride home from the funeral and a steak dinner. End of discussion.",
     "The three most useless jobs in the world in order are: lawyer, congressman, and doctor.",
-    "I've had the same will since I was 8 years old. Upon my death, I will transfer all of my belongings to the man or animal who has killed me.",,
+    "I've had the same will since I was 8 years old. Upon my death, I will transfer all of my belongings to the man or animal who has killed me.",
     "Standard birth control methods are usually ineffective against a Swanson.",
     "I believe in cutting useless government projects. I also believe in cutting useful government projects.",
     "I've never been hungover. After I've had too much whiskey, I cook myself a large flank steak, pan fried and salted butter. I eat that, put on a pair of wet socks and go to sleep.",


### PR DESCRIPTION
You have an extra comma at the end of line 105 in `src/quotes.ts`. This creates an empty slot in the array. Therefore, when the `appendRandomQuote()` function in `src/getRandomQuotes.ts` tries to get the item at `quotes[102]`, it's `undefined`. The short-circuit evaluation means that a blank string gets used instead.